### PR TITLE
Add Celery worker to schedule and process async jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ app/serviceAccountKey.json
 # Local Development
 migrations
 
+# Redis Snapshot
+dump.rdb
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -3,6 +3,7 @@ from firebase_admin import credentials
 from flask import Flask
 from .extensions import db, migrate, ma
 from .config import Config
+from celery_app import make_celery
 
 def create_app(config_class=Config):
     app = Flask(__name__)
@@ -18,7 +19,13 @@ def create_app(config_class=Config):
     ma.init_app(app)
 
     from app.main import main_bp
-
     app.register_blueprint(main_bp)
+
+    #Initialize Celery for background task of generating weekly advice
+    celery = make_celery(app)
+    app.celery = celery
+    # Import and register tasks AFTER celery is created
+    from app.celery_tasks import register_tasks
+    register_tasks(celery)
 
     return app

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,8 @@ from flask import Flask
 from .extensions import db, migrate, ma
 from .config import Config
 from celery_app import make_celery
+from app.celery_tasks import register_tasks
+
 
 def create_app(config_class=Config):
     app = Flask(__name__)
@@ -19,13 +21,13 @@ def create_app(config_class=Config):
     ma.init_app(app)
 
     from app.main import main_bp
+
     app.register_blueprint(main_bp)
 
-    #Initialize Celery for background task of generating weekly advice
+    # Initialize Celery for background task of generating weekly advice
     celery = make_celery(app)
     app.celery = celery
     # Import and register tasks AFTER celery is created
-    from app.celery_tasks import register_tasks
     register_tasks(celery)
 
     return app

--- a/app/celery_tasks.py
+++ b/app/celery_tasks.py
@@ -1,5 +1,8 @@
+from celery.utils.log import get_task_logger
 from app.tasks_logic import generate_weekly_advice_for_user
 from app.models import User
+
+logger = get_task_logger(__name__)
 
 
 def register_tasks(celery):

--- a/app/celery_tasks.py
+++ b/app/celery_tasks.py
@@ -1,6 +1,6 @@
 from app.tasks_logic import generate_weekly_advice_for_user
 from app.models import User
-from app.extensions import db
+
 
 def register_tasks(celery):
     """
@@ -9,8 +9,8 @@ def register_tasks(celery):
     Parameters:
         celery (Celery): Instance to which tasks will be registered to.
     """
-    
-    @celery.task(name='generate_all_users_weekly_advice')
+
+    @celery.task(name="generate_all_users_weekly_advice")
     def generate_all_users_weekly_advice():
         """
         Defines a Celery task that generates personalized weekly advice for each unqiue user.
@@ -22,3 +22,8 @@ def register_tasks(celery):
         for user in users:
             generate_weekly_advice_for_user(user)
         return "Completed Celery Task: Generated all users' weekly advice."
+
+    @celery.task(name="test_task")
+    def test_task():
+        print("Test task is running every 15 seconds!")
+        return "Test task completed."

--- a/app/celery_tasks.py
+++ b/app/celery_tasks.py
@@ -1,0 +1,24 @@
+from app.tasks_logic import generate_weekly_advice_for_user
+from app.models import User
+from app.extensions import db
+
+def register_tasks(celery):
+    """
+    Defines and register multiple Celery tasks with the Celery instance.
+
+    Parameters:
+        celery (Celery): Instance to which tasks will be registered to.
+    """
+    
+    @celery.task(name='generate_all_users_weekly_advice')
+    def generate_all_users_weekly_advice():
+        """
+        Defines a Celery task that generates personalized weekly advice for each unqiue user.
+
+        Returns:
+            str: Message indicating the completion status of the task.
+        """
+        users = User.query.all()
+        for user in users:
+            generate_weekly_advice_for_user(user)
+        return "Completed Celery Task: Generated all users' weekly advice."

--- a/app/config.py
+++ b/app/config.py
@@ -18,9 +18,9 @@ class Config:
     RESULT_BACKEND = os.environ.get("RESULT_BACKEND") or "redis://localhost:6379/0"
 
     CELERY_BEAT_SCHEDULE = {
-        "run-test-task-every-15-seconds": {
-            "task": "test_task",
-            "schedule": timedelta(seconds=15),
+        "weekly-advice-generation": {
+            "task": "generate_all_users_weekly_advice",
+            "schedule": timedelta(seconds=60),
             "args": (),
         },
     }

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 
 # Get the base directory of the current file
 basedir = os.path.abspath(os.path.dirname(__file__))
@@ -15,3 +16,11 @@ class Config:
     # Celery Configuration
     BROKER_URL = os.environ.get("BROKER_URL") or "redis://localhost:6379/0"
     RESULT_BACKEND = os.environ.get("RESULT_BACKEND") or "redis://localhost:6379/0"
+
+    CELERY_BEAT_SCHEDULE = {
+        "run-test-task-every-15-seconds": {
+            "task": "test_task",
+            "schedule": timedelta(seconds=15),
+            "args": (),
+        },
+    }

--- a/app/config.py
+++ b/app/config.py
@@ -7,9 +7,11 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 class Config:
     # Secret key for CSRF protection
     SECRET_KEY = os.environ.get("SECRET_KEY")
-    SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL") or "sqlite:///" + os.path.join(basedir, "app.db")
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "DATABASE_URL"
+    ) or "sqlite:///" + os.path.join(basedir, "app.db")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     # Celery Configuration
-    CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
-    CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+    BROKER_URL = os.environ.get("BROKER_URL") or "redis://localhost:6379/0"
+    RESULT_BACKEND = os.environ.get("RESULT_BACKEND") or "redis://localhost:6379/0"

--- a/app/config.py
+++ b/app/config.py
@@ -9,3 +9,7 @@ class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY")
     SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL") or "sqlite:///" + os.path.join(basedir, "app.db")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    # Celery Configuration
+    CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
+    CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")

--- a/app/models/weekly_advice.py
+++ b/app/models/weekly_advice.py
@@ -1,6 +1,7 @@
 from marshmallow import validate
 from app.extensions import db, ma
 
+
 class WeeklyAdvice(db.Model):
     """
     WeeklyAdvice model representing advice provided to a user on a weekly basis.
@@ -12,6 +13,7 @@ class WeeklyAdvice(db.Model):
     user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
     content = db.Column(db.Text, nullable=False)
     created_at = db.Column(db.DateTime, default=db.func.now())
+    of_week = db.Column(db.DateTime, default=db.func.now())
 
     def __repr__(self):
         return f"<WeeklyAdvice {self.id} for User {self.user_id}>"
@@ -20,10 +22,6 @@ class WeeklyAdvice(db.Model):
 class WeeklyAdviceSchema(ma.SQLAlchemySchema):
     """
     Marshmallow schema for serializing and deserializing WeeklyAdvice instances.
-
-    Data Validation:
-    - user_id: Required
-    - content: Required and cannot be empty
     """
 
     class Meta:
@@ -32,5 +30,6 @@ class WeeklyAdviceSchema(ma.SQLAlchemySchema):
 
     id = ma.auto_field()
     user_id = ma.auto_field(dump_only=True)
-    content = ma.auto_field(required=True, validate=validate.Length(min=1))
-    created_at = ma.auto_field()
+    content = ma.auto_field(dump_only=True, validate=validate.Length(min=1))
+    created_at = ma.auto_field(dump_only=True)
+    of_week = ma.auto_field(dump_only=True)

--- a/app/tasks_logic.py
+++ b/app/tasks_logic.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timezone, timedelta
+from app.models import User, Post, WeeklyAdvice
+from app.extensions import db
+from flask import current_app
+
+def generate_advice(posts):
+    """
+    Invokes OpenAI API to generate personalized advice based on the posts.
+
+    Parameters:
+        posts (list): List of posts from an user.
+    
+    Returns:
+        openAI_response (str): Formatted string of user posts.
+    """
+    prompt = "User had the following posts last week: \n\n"
+    for post in posts:
+        prompt += f"{post.content}\n"
+    return prompt
+
+def generate_weekly_advice_for_user(user):
+    """
+    Queries the user's posts from specified days, calls OpenAI API to generates personalized weekly advice, and stores output advice in the weekly_advice database.
+    
+    Parameters:
+        user (User): User for whom the advice is to be generated.
+    
+    Returns:
+        weekly_advice: Generated weekly advice through OpenAI API.
+    """
+    retrieval_window = datetime.now(timezone.utc) - timedelta(days=7)
+    posts = Post.query.filter(
+        Post.user_id == user.id,
+        Post.created_at >= retrieval_window
+    ).all()
+
+    if not posts:
+        return None
+
+    advice_content = generate_advice(posts)
+    if advice_content:
+        weekly_advice = WeeklyAdvice(user_id=user.id, content=advice_content)
+        db.session.add(weekly_advice)
+        db.session.commit()
+        return weekly_advice
+    return None

--- a/app/tasks_logic.py
+++ b/app/tasks_logic.py
@@ -1,7 +1,9 @@
 from datetime import datetime, timezone, timedelta
-from app.models import User, Post, WeeklyAdvice
+from app.models import Post, WeeklyAdvice
 from app.extensions import db
 from flask import current_app
+import openai
+
 
 def generate_advice(posts):
     """
@@ -9,29 +11,56 @@ def generate_advice(posts):
 
     Parameters:
         posts (list): List of posts from an user.
-    
+
     Returns:
         openAI_response (str): Formatted string of user posts.
     """
-    prompt = "User had the following posts last week: \n\n"
+    prompt = "The user had the following posts last week:\n\n"
     for post in posts:
-        prompt += f"{post.content}\n"
-    return prompt
+        prompt += f"- {post.content}\n"
+
+    prompt += (
+        "\nGiven these entries, please provide a short, encouraging piece of weekly advice "
+        "focused on mental health and well-being. The advice should be empathetic, "
+        "supportive, and actionable, guiding the user on how to approach the coming week."
+    )
+
+    openai.api_key = current_app.config.get("OPENAI_API_KEY")
+
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a supportive mental health profession who gives actionable tips.",
+                },
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.7,
+            max_tokens=250,
+        )
+        advice_content = response["choices"][0]["message"]["content"].strip()
+        return advice_content
+    except Exception as e:
+        current_app.logger.error(f"OpenAI API call failed: {e}")
+        return None
+
 
 def generate_weekly_advice_for_user(user):
     """
-    Queries the user's posts from specified days, calls OpenAI API to generates personalized weekly advice, and stores output advice in the weekly_advice database.
-    
+    Queries the user's posts from specified days, calls OpenAI API to generates personalized weekly
+    advice, and stores output advice in the weekly_advice database.
+
     Parameters:
         user (User): User for whom the advice is to be generated.
-    
+
     Returns:
         weekly_advice: Generated weekly advice through OpenAI API.
     """
-    retrieval_window = datetime.now(timezone.utc) - timedelta(days=7)
+    retrieval_window = datetime.now(timezone.utc) - timedelta(seconds=60)
     posts = Post.query.filter(
-        Post.user_id == user.id,
-        Post.created_at >= retrieval_window
+        Post.user_id == user.id, Post.created_at >= retrieval_window
     ).all()
 
     if not posts:

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,29 +1,46 @@
 from celery import Celery
+from celery.schedules import crontab
+
 
 def make_celery(app):
     """
-    A factory function to create a Celery instance that is aware of Flask application's context and configuration variables.
+    A factory function to create a Celery instance that is aware
+    of Flask application's context and configuration variables.
 
     Parameters:
         app (Flask) : Flask application instance
-    
+
     Returns:
         Celery : Configured Celery instance
     """
-    celery = Celery(app.import_name, 
-                    broker=app.config['CELERY_BROKER_URL'],
-                    backend=app.config['CELERY_RESULT_BACKEND'])
-    celery.conf.update(app.config)
+    celery = Celery(app.import_name)
+    celery.conf.broker_url = app.config["BROKER_URL"]
+    celery.conf.result_backend = app.config["RESULT_BACKEND"]
 
     TaskBase = celery.Task
+
     class ContextTask(TaskBase):
         """
-        Baseline Task class to wrap every Celery task with Flask application context, allowing access to OpenAI API key, database connection, and etc.
+        Baseline Task class to wrap every Celery task with Flask
+        application context, allowing access to OpenAI API key,
+        database connection, and etc.
         """
+
         abstract = True
+
         def __call__(self, *args, **kwargs):
             with app.app_context():
                 return TaskBase.__call__(self, *args, **kwargs)
 
     celery.Task = ContextTask
+    celery.conf.timezone = "UTC"
+
+    # Setup a weekly schedule
+    celery.conf.beat_schedule = {
+        "generate-weekly-advice-every-sunday-midnight": {
+            "task": "generate_all_users_weekly_advice",
+            "schedule": crontab(day_of_week="sunday", hour=0, minute=0),
+        }
+    }
+
     return celery

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,5 +1,4 @@
 from celery import Celery
-from celery.schedules import crontab
 
 
 def make_celery(app):
@@ -34,13 +33,5 @@ def make_celery(app):
 
     celery.Task = ContextTask
     celery.conf.timezone = "UTC"
-
-    # Setup a weekly schedule
-    celery.conf.beat_schedule = {
-        "generate-weekly-advice-every-sunday-midnight": {
-            "task": "generate_all_users_weekly_advice",
-            "schedule": crontab(day_of_week="sunday", hour=0, minute=0),
-        }
-    }
 
     return celery

--- a/celery_app.py
+++ b/celery_app.py
@@ -15,6 +15,7 @@ def make_celery(app):
     celery = Celery(app.import_name)
     celery.conf.broker_url = app.config["BROKER_URL"]
     celery.conf.result_backend = app.config["RESULT_BACKEND"]
+    celery.conf.beat_schedule = app.config["CELERY_BEAT_SCHEDULE"]
 
     TaskBase = celery.Task
 

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,0 +1,29 @@
+from celery import Celery
+
+def make_celery(app):
+    """
+    A factory function to create a Celery instance that is aware of Flask application's context and configuration variables.
+
+    Parameters:
+        app (Flask) : Flask application instance
+    
+    Returns:
+        Celery : Configured Celery instance
+    """
+    celery = Celery(app.import_name, 
+                    broker=app.config['CELERY_BROKER_URL'],
+                    backend=app.config['CELERY_RESULT_BACKEND'])
+    celery.conf.update(app.config)
+
+    TaskBase = celery.Task
+    class ContextTask(TaskBase):
+        """
+        Baseline Task class to wrap every Celery task with Flask application context, allowing access to OpenAI API key, database connection, and etc.
+        """
+        abstract = True
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery

--- a/run.py
+++ b/run.py
@@ -1,6 +1,17 @@
+"""
+run.py
+
+Entry point for creating and running the Flask application. It also initializes and exposes the Celery instance for processing lengthly background task such as generating weekly advice for users.
+"""
+
 from app import create_app
 
+# Create an instance of the Flask application using the factory function
 app = create_app()
 
+# Access the Celery instance from the Flask app
+celery = app.celery
+
+# Start the Flask server
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
## Overview

This pull request introduces Celery and Celery Beat, which schedule weekly tasks that query all posts from every user within a seven-day window. A worker then calls OpenAI to generate mental health advice and stores the results in a database table.

- **Type of Change:**
  - [ ] Bug Fix
  - New Feature
  - [ ] Enhancement
  - [ ] Documentation
  - [ ] Other: _______

## Testing

<!-- Indicate the types of testing performed. -->

- **Unit Tests Added:**
  - [ ] Yes
  - No
- **Integration Tests Added:**
  - Yes
  - [ ] No
- **Manual Testing Performed:**
  - Yes
  - [ ] No

## Additional Notes

This code is currently intended for local development. Therefore, it uses a Redis server as a message broker to queue the weekly jobs. RabbitMQ and a cluster of workers will be implemented for the production environment.