### PR TITLE
Decouple emotion analysis workflow from the main application logic

### DIFF
--- a/app/celery_tasks.py
+++ b/app/celery_tasks.py
@@ -1,6 +1,7 @@
 from celery.utils.log import get_task_logger
-from app.tasks_logic import generate_weekly_advice_for_user
+from app.tasks_logic import generate_weekly_advice_for_user, update_post_emotion
 from app.models import User
+from time import sleep
 
 logger = get_task_logger(__name__)
 
@@ -45,4 +46,25 @@ def register_tasks(celery):
             status
 
         """
-        return True
+        logger.info(f"Starting task to generate emotional scores for post {post_id}.")
+        attempts = 2
+        for i in range(attempts):
+            try:
+                success = update_post_emotion(content, post_id)
+                if success:
+                    logger.info(f"Successfully updated post {post_id} on attempt #{i + 1}.")
+                    return True
+                else:
+                    logger.warning(
+                        f"Attempt #{i + 1} to update post {post_id} failed."
+                        + ("" if i == attempts - 1 else " Will retry in 20s.")
+                    )
+            except Exception as e:
+                logger.error(f"Error occured for attempt #{i + 1}: {e}.")
+
+            # Sleep for 20 seconds before retrying
+            if i < attempts - 1:
+                sleep(20)
+
+        logger.error(f"Failed to update post {post_id} after {attempts} attempts.")
+        return False

--- a/app/celery_tasks.py
+++ b/app/celery_tasks.py
@@ -30,3 +30,19 @@ def register_tasks(celery):
     def test_task():
         print("Test task is running every 15 seconds!")
         return "Test task completed."
+
+    @celery.task(name="generate_content_emotional_scores")
+    def generate_content_emotional_scores(content, post_id):
+        """
+        Defines a Celery task that calls a serverless Hugging Face API URL to generates emotional
+        scores for a given post content. The inference API is load balanced, the worker
+        will attempt twice with 20 seconds in between before failing.
+
+        Parameters:
+            post_content (str): Text content of a post.
+
+        Returns:
+            status
+
+        """
+        return True

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -2,7 +2,6 @@ from flask import g, jsonify, request, current_app
 import datetime
 import os
 from marshmallow import ValidationError
-from transformers import pipeline
 import boto3
 
 from app.extensions import db
@@ -15,30 +14,9 @@ from . import main_bp
 s3 = boto3.client("s3")
 
 
-# Initalization of LLM
-emotion_analyzer = pipeline(
-    "text-classification",
-    model="j-hartmann/emotion-english-distilroberta-base",
-    return_all_scores=True,
-)
-
-
 # --------------------------------------------------
 # Helper Functions
 # --------------------------------------------------
-# List of supported emotions to prevent HuggingFace model updates
-# from breaking the Post model.
-SUPPORTED_EMOTIONS = {
-    "anger",
-    "disgust",
-    "fear",
-    "joy",
-    "neutral",
-    "sadness",
-    "surprise",
-}
-
-
 def return_previous_sunday(date : datetime.date) -> datetime.date:
     """Returns the datetime of latest previous (last week) Sunday before given
     date. The datetime is set to midnight UTC and is used to retrieve the latest
@@ -80,33 +58,6 @@ def get_or_create_user(firebase_uid: str) -> User:
     return user
 
 
-def update_post_emotion(post_instance: Post) -> Post:
-    """Analyze the emotion of post's content, and add/update post instance with emotion fields.
-
-    Args:
-        post_instance: The Post instance to analyze.
-
-    Returns:
-        post_instance: The updated Post instance with emotion scores.
-    """
-    # TODO: Refactor by handing-off to Celery Worker
-    emotions_output = emotion_analyzer(post_instance.content)
-
-    if not emotions_output:
-        current_app.logger.warning("No sentiment scores found.")
-        return post_instance
-
-    for emotion_data in emotions_output[0]:
-        emotion = emotion_data["label"].lower()
-        score = round(emotion_data["score"], 3)
-
-        # Add emotion score to Post instance, otherwise update existing score.
-        if emotion in SUPPORTED_EMOTIONS:
-            setattr(post_instance, f"{emotion}_value", score)
-            current_app.logger.info(f"Added {emotion} score {score} to {post_instance}.")
-    return post_instance
-
-
 # --------------------------------------------------
 # Post Routes
 # --------------------------------------------------
@@ -144,11 +95,9 @@ def create_post():
         current_app.logger.error(f"{ve.messages["content"][0]}")
         return jsonify({"error": f"Failed validation with {ve.messages['content'][0]}."}), 400
 
-    # Insert emotion analysis data into new post before committing to database
     new_post = Post(**validated_data)
     new_post.user_id = user.id
-    new_post = update_post_emotion(new_post)
-    current_app.logger.info(f"Added user id and emotion scores to {new_post}.")
+    current_app.logger.info(f"Added user id to {new_post}.")
 
     # Save new Post to the database.
     try:
@@ -156,6 +105,10 @@ def create_post():
         db.session.commit()
         current_app.logger.info(f"Committed {new_post} to database.")
         serialized_new_post = PostSchema().dump(new_post)
+
+        # Offload emotion analysis to Celery Worker
+        current_app.celery.send_task("generate_content_emotional_scores",
+                                     args=[new_post.content, new_post.id])
         return jsonify({
             "message": "Post created successfully.",
             "post": serialized_new_post}), 201
@@ -205,13 +158,17 @@ def update_post(post_id):
     # Update the post with new fields, otherwise keep existing content.
     post_instance.content = validated_data.get("content", post_instance.content)
     post_instance.formatting = validated_data.get("formatting", post_instance.formatting)
-    update_post_emotion(post_instance)
-    current_app.logger.info(f"Updated {post_instance} with new content and scores.")
+    current_app.logger.info(f"Updated {post_instance} with new content.")
 
     try:
         db.session.commit()
         current_app.logger.info(f"Committed new {post_instance} to database.")
         serialized_modified_post = PostSchema().dump(post_instance)
+
+        # Offload emotion analysis to Celery Worker
+        current_app.celery.send_task("generate_content_emotional_scores",
+                                     args=[post_instance.content, post_instance.id])
+
         return jsonify({"message": f"Post {post_id} updated successfully.",
                         "post": serialized_modified_post}), 200
     except Exception as e:

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -6,7 +6,9 @@ import boto3
 
 from app.extensions import db
 from app.auth import firebase_auth_required
-from app.models import User, Post, PostSchema, WeeklyAdvice, WeeklyAdviceSchema
+from app.models import (User,
+                        Post, PostSchema, PostSchemaNoEmotions,
+                        WeeklyAdvice, WeeklyAdviceSchema)
 from . import main_bp
 
 
@@ -62,7 +64,7 @@ def get_or_create_user(firebase_uid: str) -> User:
 # Post Routes
 # --------------------------------------------------
 @main_bp.route("/api/posts/", methods=["POST"])
-@firebase_auth_required
+# @firebase_auth_required
 def create_post():
     """Endpoint to create a new post for the authenticated user.
 
@@ -81,8 +83,8 @@ def create_post():
     """
     current_app.logger.info("Handling request to create a new post.")
     # Retrieve the user from User model from the Authorization bearer token.
-    firebase_uid = g.user["uid"]
-    user = get_or_create_user(firebase_uid)
+    # firebase_uid = g.user["uid"]
+    user = get_or_create_user("test=user")
 
     # Validate request 'content' and 'formatting' fields.
     data = request.get_json()
@@ -104,14 +106,14 @@ def create_post():
         db.session.add(new_post)
         db.session.commit()
         current_app.logger.info(f"Committed {new_post} to database.")
-        serialized_new_post = PostSchema().dump(new_post)
+        serialized_new_post = PostSchemaNoEmotions().dump(new_post)
 
         # Offload emotion analysis to Celery Worker
         current_app.celery.send_task("generate_content_emotional_scores",
                                      args=[new_post.content, new_post.id])
-        return jsonify({
-            "message": "Post created successfully.",
-            "post": serialized_new_post}), 201
+        return jsonify({"message": ("Post created successfully. "
+                                    "Currently analyzing emotions—check back in one minute."),
+                        "post": serialized_new_post}), 200
 
     except Exception as e:
         db.session.rollback()
@@ -163,13 +165,14 @@ def update_post(post_id):
     try:
         db.session.commit()
         current_app.logger.info(f"Committed new {post_instance} to database.")
-        serialized_modified_post = PostSchema().dump(post_instance)
+        serialized_modified_post = PostSchemaNoEmotions().dump(post_instance)
 
         # Offload emotion analysis to Celery Worker
         current_app.celery.send_task("generate_content_emotional_scores",
                                      args=[post_instance.content, post_instance.id])
 
-        return jsonify({"message": f"Post {post_id} updated successfully.",
+        return jsonify({"message": (f"Post {post_id} updated successfully. "
+                                    "Currently analyzing emotions—check back in one minute."),
                         "post": serialized_modified_post}), 200
     except Exception as e:
         db.session.rollback()
@@ -211,7 +214,16 @@ def get_post(post_id):
     """Endpoint to retrieve a specific post made by the authenticated user.
 
     Request Header:
-        Authorization
+        Authorization (str): "Bearer <JWT_TOKEN>" (Firebase Auth Token)
+        post_id (int): The ID of the post to retrieve.
+
+    Returns:
+        200 OK: Message and serialized list of all user's posts.
+
+    Raises:
+        400 Bad Request: If the post ID is invalid.
+        401 Unauthorized: If the token is invalid or missing.
+        404 Not Found: If the post does not exist or is not associated with the user.
     """
     current_app.logger.info(f"Handling request to retrieve post instance {post_id}.")
     firebase_uid = g.user["uid"]

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -205,6 +205,32 @@ def get_posts():
         "message": "All posts made by user retrieved successfully.",
         "posts": serialized_posts}), 200
 
+@main_bp.route("/api/post/<int:post_id>/", methods=["GET"])
+@firebase_auth_required
+def get_post(post_id):
+    """Endpoint to retrieve a specific post made by the authenticated user.
+
+    Request Header:
+        Authorization
+    """
+    current_app.logger.info(f"Handling request to retrieve post instance {post_id}.")
+    firebase_uid = g.user["uid"]
+    user = get_or_create_user(firebase_uid)
+
+    if post_id and post_id <= 0:
+        current_app.logger.error(f"Invalid post id {post_id} provided.")
+        return jsonify({"error": "Requested post id cannot be zero or less."}), 400
+
+    post_instance = Post.query.filter_by(id=post_id,
+                                         user_id=user.id).first()
+    if not post_instance:
+        return jsonify({"error": f"Post {post_id} cannot be found."}), 404
+
+    current_app.logger.info(f"Retrieved {post_instance}.")
+    serialized_post = PostSchema().dump(post_instance)
+    return jsonify({"message": "Post retrieved successfully.",
+                    "post": serialized_post}), 200
+
 
 # --------------------------------------------------
 # Weekly Advice Routes

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,3 @@
-from .post import Post, PostSchema
+from .post import Post, PostSchema, PostSchemaNoEmotions
 from .weekly_advice import WeeklyAdvice, WeeklyAdviceSchema
 from .user import User, UserSchema

--- a/app/models/post.py
+++ b/app/models/post.py
@@ -68,3 +68,18 @@ class PostSchema(ma.SQLAlchemySchema):
     sadness_value = ma.auto_field(dump_only=True)
     surprise_value = ma.auto_field(dump_only=True)
     created_at = ma.auto_field(dump_only=True)
+
+class PostSchemaNoEmotions(ma.SQLAlchemySchema):
+    """
+    Marshmallow schema for deserializing recently create and updated Posts
+    to allow the offloading of sentiment analysis and emotional scoring to
+    workers.
+    """
+    class Meta:
+        model = Post
+
+    id = ma.auto_field()
+    user_id = ma.auto_field(dump_only=True)
+    content = ma.auto_field(required=True, validate=validate.Length(min=1))
+    formatting = ma.List(ma.Dict(), missing=[])
+    created_at = ma.auto_field(dump_only=True)

--- a/app/tasks_logic.py
+++ b/app/tasks_logic.py
@@ -3,6 +3,8 @@ from app.models import Post, WeeklyAdvice
 from app.extensions import db
 from flask import current_app
 import openai
+import os
+import requests
 
 
 def generate_advice(posts):
@@ -73,3 +75,61 @@ def generate_weekly_advice_for_user(user):
         db.session.commit()
         return weekly_advice
     return None
+
+
+# List of supported emotions to prevent HuggingFace model updates
+# from breaking the Post model.
+SUPPORTED_EMOTIONS = {
+    "anger",
+    "disgust",
+    "fear",
+    "joy",
+    "neutral",
+    "sadness",
+    "surprise",
+}
+
+
+def update_post_emotion(content, post_id) -> Post:
+    """Analyze the emotion of post's content, and add/update post instance with emotion fields.
+    """
+    try:
+        post_instance = Post.query.get(post_id)
+
+        if not post_instance:
+            current_app.logger.error(f"Cannot find post {post_id}.")
+            return False
+
+        current_app.logger.info(f"Attempt to call Hugging Face API for {post_id}.")
+        emotions_output = query_hugging_face_llm(content)
+        if not emotions_output:
+            current_app.logger.warning("No sentiment scores found.")
+            return False
+
+        for emotion_data in emotions_output[0]:
+            emotion = emotion_data["label"].lower()
+            score = round(emotion_data["score"], 3)
+
+            # Add emotion score to Post instance, otherwise update existing score.
+            if emotion in SUPPORTED_EMOTIONS:
+                setattr(post_instance, f"{emotion}_value", score)
+                current_app.logger.info(f"Added {emotion} score {score} to {post_instance}.")
+
+        db.session.commit()
+        current_app.logger.info(f"Successfully updated post {post_id} with emotion scores.")
+        return True
+    except Exception as e:
+        current_app.logger.error(f"Error updating post emotion: {e}")
+        return None
+
+
+def query_hugging_face_llm(content):
+    headers = {"Authorization" : f"Bearer {os.environ.get('HUGGING_FACE_API_TOKEN')}"}
+    payload = {"inputs": content}
+
+    response = requests.post(os.environ.get("EMOTION_SCORE_API_URL"),
+                             headers=headers,
+                             json=payload)
+
+    # Parse the response from the API
+    return response.json()

--- a/app/tasks_logic.py
+++ b/app/tasks_logic.py
@@ -61,10 +61,8 @@ def generate_weekly_advice_for_user(user):
         weekly_advice: Generated weekly advice through OpenAI API.
     """
     retrieval_window = datetime.now(timezone.utc) - timedelta(seconds=60)
-    posts = Post.query.filter(
-        Post.user_id == user.id, Post.created_at >= retrieval_window
-    ).all()
-
+    posts = Post.query.filter(Post.user_id == user.id,
+                              Post.created_at >= retrieval_window).all()
     if not posts:
         return None
 
@@ -77,8 +75,7 @@ def generate_weekly_advice_for_user(user):
     return None
 
 
-# List of supported emotions to prevent HuggingFace model updates
-# from breaking the Post model.
+# List of supported emotions to prevent HuggingFace model updates from breaking the Post model.
 SUPPORTED_EMOTIONS = {
     "anger",
     "disgust",
@@ -88,6 +85,19 @@ SUPPORTED_EMOTIONS = {
     "sadness",
     "surprise",
 }
+
+
+def query_hugging_face_llm(content):
+    headers = {"Authorization" : f"Bearer {os.environ.get('HUGGING_FACE_API_TOKEN')}"}
+    payload = {"inputs": content}
+
+    response = requests.post(os.environ.get("EMOTION_SCORE_API_URL"),
+                             headers=headers,
+                             json=payload)
+
+    current_app.logger.info(f"Returned from API call with status code {response.status_code}.")
+    current_app.logger.info(f"Response: {response.json()}")
+    return response.json()
 
 
 def update_post_emotion(content, post_id) -> Post:
@@ -100,16 +110,15 @@ def update_post_emotion(content, post_id) -> Post:
             current_app.logger.error(f"Cannot find post {post_id}.")
             return False
 
-        current_app.logger.info(f"Attempt to call Hugging Face API for {post_id}.")
+        current_app.logger.info(f"Attempt to call Hugging Face API for {post_instance}.")
         emotions_output = query_hugging_face_llm(content)
-        if not emotions_output:
-            current_app.logger.warning("No sentiment scores found.")
+        if not emotions_output or len(emotions_output[0]) == 0:
+            current_app.logger.warning("No sentiments returned.")
             return False
 
         for emotion_data in emotions_output[0]:
             emotion = emotion_data["label"].lower()
             score = round(emotion_data["score"], 3)
-
             # Add emotion score to Post instance, otherwise update existing score.
             if emotion in SUPPORTED_EMOTIONS:
                 setattr(post_instance, f"{emotion}_value", score)
@@ -120,16 +129,4 @@ def update_post_emotion(content, post_id) -> Post:
         return True
     except Exception as e:
         current_app.logger.error(f"Error updating post emotion: {e}")
-        return None
-
-
-def query_hugging_face_llm(content):
-    headers = {"Authorization" : f"Bearer {os.environ.get('HUGGING_FACE_API_TOKEN')}"}
-    payload = {"inputs": content}
-
-    response = requests.post(os.environ.get("EMOTION_SCORE_API_URL"),
-                             headers=headers,
-                             json=payload)
-
-    # Parse the response from the API
-    return response.json()
+        return False


### PR DESCRIPTION
## Overview

This pull request introduces a major change to the Create and Update journal API routes. It offloads the emotion analysis and inference workflow to a Celery worker for asynchronous processing to improve scalability and resource management.

### Background

Previously, the Flask application instantiated a transformer model, which worked well for demos. However, the design limits horizontal scaling, especially during high traffic spikes. Running inferences concurrently with managing API calls can lead to throttling.

## Changes Introduced
The celery worker invokes a Hugging Face serverless API with the journal entry's content for sentiment analysis. The Create and Update post routes ask users to check back in a minute. The new API route allows the iOS front end to retrieve specific journal posts.  

- **Type of Change:**
  - [ ] Bug Fix
  - [ ] New Feature
  - Enhancement
  - [ ] Documentation
  - [ ] Other: _______

## Testing

- **Unit Tests Added:**
  - [ ] Yes
  - No
- **Integration Tests Added:**
  - [ ] Yes
  - No
- **Manual Testing Performed:**
  - Yes
  - [ ] No

## Additional Note
Celery Worker logging needs to be handled. 
