### PR TITLE
Add gunicorn and nginx proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,10 +37,16 @@ services:
       - FLASK_APP=run.py
     env_file:
       - .env
-    ports:
-      - "8000:8000"
-    command: ["flask", "run", "--host=0.0.0.0", "--port=8000"]
-
+    # Exposes the port only to service containers within same Docker network
+    expose:
+      - "8000"
+    command: >
+      gunicorn run:app 
+      --bind 0.0.0.0:8000 
+      --workers 4
+      --threads 2
+      --timeout 60
+  
   celery_worker:
     build:
       context: .
@@ -64,6 +70,16 @@ services:
     env_file:
       - .env
     command: ["celery", "-A", "run.celery", "beat", "--loglevel=info"]
+
+  nginx:
+    image: nginx:latest
+    container_name: nginx_proxy
+    depends_on:
+      - flask
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 
 volumes:
   pgdata:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name _;
+
+    # Forward HTTP calls to Gunicorn to be executed in 'flask' service container
+    location / {
+        proxy_pass http://flask:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ google-resumable-media==2.7.2
 googleapis-common-protos==1.66.0
 grpcio==1.68.1
 grpcio-status==1.68.1
+gunicorn==23.0.0
 h11==0.14.0
 httpcore==1.0.7
 httplib2==0.22.0


### PR DESCRIPTION
## Overview

This pull request introduces server and port updates to the Docker setup through Gunicorn and Nginx. 

The Flask service is now configured to run with Gunicorn instead of its built-in development server, improving request handling and performance. Nginx has been added to manage external port exposure. With direct access to the Flask service restricted, Nginx will forward incoming HTTP requests on port 80 to the Flask service running on Gunicorn. 