### PR TITLE
Add Celery workers' concurrency level and fix minor API bug

### DIFF
--- a/app/main/routes_advices.py
+++ b/app/main/routes_advices.py
@@ -5,7 +5,7 @@ from app.utils.auth import firebase_auth_required, get_or_create_user
 from app.utils.time import latest_monday
 
 
-@main_bp.route("/api/advice/latest", methods=["GET"])
+@main_bp.route("/api/advice/latest/", methods=["GET"])
 @firebase_auth_required
 def get_latest_weekly_advice():
     """Endpoint to retrieve the latest weekly advice for the authenticated user."""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,8 @@ services:
       - postgres
     env_file:
       - .env
-    command: ["celery", "-A", "run.celery", "worker", "--loglevel=info"]
+    # Worker instance processes one tasks at a time -> max concurrent job = (num of workers * concurrency rate) 
+    command: ["celery", "-A", "run.celery", "worker", "--loglevel=info", "--concurrency=1"]
 
   celery_beat:
     build:


### PR DESCRIPTION
## Overview

This pull request specifies the number of tasks a worker can take on. By setting concurrency to one, a worker instance must complete its current task before dequeuing another task from the RabbitMQ message broker. A minor change includes adding '/' to the API route to retrieve a user's latest advice. 