### PR TITLE
Edit Docker setup to allow multiple Celery Workers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.celery
-    container_name: celery_worker
     depends_on:
       - rabbitmq
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,8 @@ services:
       - postgres
     env_file:
       - .env
-    command: ["celery", "-A", "run.celery", "worker", "--loglevel=info"]
+    # Worker instance processes one tasks at a time -> max concurrent job = (num of workers * concurrency rate) 
+    command: ["celery", "-A", "run.celery", "worker", "--loglevel=info", "--concurrency=1"]
 
   celery_beat:
     build:


### PR DESCRIPTION
## Overview

This pull request introduces the ability to scale worker instances and their concurrency level, or the number of tasks a worker can take. 

When the container name is omitted, Docker Compose will create multiple worker containers, each with a unique name. If concurrency is set to one, a worker instance must finish its current task before it can dequeue another task from the RabbitMQ message broker.